### PR TITLE
Refactor datetime imports

### DIFF
--- a/tests/auxil/bot_method_checks.py
+++ b/tests/auxil/bot_method_checks.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
 """Provides functions to test both methods."""
-import datetime
+import datetime as dtm
 import functools
 import inspect
 import re
@@ -336,12 +336,10 @@ def build_kwargs(
         elif name == "until_date":
             if manually_passed_value not in [None, DEFAULT_NONE]:
                 # Europe/Berlin
-                kws[name] = pytz.timezone("Europe/Berlin").localize(
-                    datetime.datetime(2000, 1, 1, 0)
-                )
+                kws[name] = pytz.timezone("Europe/Berlin").localize(dtm.datetime(2000, 1, 1, 0))
             else:
                 # naive UTC
-                kws[name] = datetime.datetime(2000, 1, 1, 0)
+                kws[name] = dtm.datetime(2000, 1, 1, 0)
         elif name == "reply_parameters":
             kws[name] = telegram.ReplyParameters(
                 message_id=1,

--- a/tests/auxil/build_messages.py
+++ b/tests/auxil/build_messages.py
@@ -16,7 +16,7 @@
 #
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
-import datetime
+import datetime as dtm
 import re
 
 from telegram import Chat, Message, MessageEntity, Update, User
@@ -24,7 +24,7 @@ from tests.auxil.ci_bots import BOT_INFO_PROVIDER
 from tests.auxil.pytest_classes import make_bot
 
 CMD_PATTERN = re.compile(r"/[\da-z_]{1,32}(?:@\w{1,32})?")
-DATE = datetime.datetime.now()
+DATE = dtm.datetime.now()
 
 
 def make_message(text: str, offline: bool = True, **kwargs):

--- a/tests/auxil/timezones.py
+++ b/tests/auxil/timezones.py
@@ -16,10 +16,10 @@
 #
 #  You should have received a copy of the GNU Lesser Public License
 #  along with this program.  If not, see [http://www.gnu.org/licenses/].
-import datetime
+import datetime as dtm
 
 
-class BasicTimezone(datetime.tzinfo):
+class BasicTimezone(dtm.tzinfo):
     def __init__(self, offset, name):
         self.offset = offset
         self.name = name
@@ -28,4 +28,4 @@ class BasicTimezone(datetime.tzinfo):
         return self.offset
 
     def dst(self, dt):
-        return datetime.timedelta(0)
+        return dtm.timedelta(0)

--- a/tests/ext/test_businessconnectionhandler.py
+++ b/tests/ext/test_businessconnectionhandler.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 import asyncio
-import datetime
+import datetime as dtm
 
 import pytest
 
@@ -71,7 +71,7 @@ def false_update(request):
 
 @pytest.fixture(scope="class")
 def time():
-    return datetime.datetime.now(tz=UTC)
+    return dtm.datetime.now(tz=UTC)
 
 
 @pytest.fixture(scope="class")
@@ -80,7 +80,7 @@ def business_connection(bot):
         id="1",
         user_chat_id=1,
         user=User(1, "name", username="user_a", is_bot=False),
-        date=datetime.datetime.now(tz=UTC),
+        date=dtm.datetime.now(tz=UTC),
         can_reply=True,
         is_enabled=True,
     )

--- a/tests/test_messageorigin.py
+++ b/tests/test_messageorigin.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-import datetime
+import datetime as dtm
 import inspect
 from copy import deepcopy
 
@@ -39,7 +39,7 @@ ignored = ["self", "api_kwargs"]
 
 
 class MODefaults:
-    date: datetime.datetime = to_timestamp(datetime.datetime.utcnow())
+    date: dtm.datetime = to_timestamp(dtm.datetime.utcnow())
     chat = Chat(1, Chat.CHANNEL)
     message_id = 123
     author_signautre = "PTB"
@@ -106,7 +106,7 @@ def iter_args(
         if param.name in ignored:
             continue
         inst_at, json_at = getattr(instance, param.name), getattr(de_json_inst, param.name)
-        if isinstance(json_at, datetime.datetime):  # Convert datetime to int
+        if isinstance(json_at, dtm.datetime):  # Convert datetime to int
             json_at = to_timestamp(json_at)
         if (
             param.default is not inspect.Parameter.empty and include_optional

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-from datetime import datetime, timedelta, timezone
+import datetime as dtm
 
 import pytest
 
@@ -297,7 +297,7 @@ class PollTestBase:
     ).decode("unicode-escape")
     explanation_entities = [MessageEntity(13, 17, MessageEntity.URL)]
     open_period = 42
-    close_date = datetime.now(timezone.utc)
+    close_date = dtm.now(dtm.timezone.utc)
     question_entities = [
         MessageEntity(MessageEntity.BOLD, 0, 4),
         MessageEntity(MessageEntity.ITALIC, 5, 8),
@@ -339,7 +339,7 @@ class TestPollWithoutRequest(PollTestBase):
         assert poll.explanation == self.explanation
         assert poll.explanation_entities == tuple(self.explanation_entities)
         assert poll.open_period == self.open_period
-        assert abs(poll.close_date - self.close_date) < timedelta(seconds=1)
+        assert abs(poll.close_date - self.close_date) < dtm.timedelta(seconds=1)
         assert to_timestamp(poll.close_date) == to_timestamp(self.close_date)
         assert poll.question_entities == tuple(self.question_entities)
 

--- a/tests/test_stars.py
+++ b/tests/test_stars.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program. If not, see [http://www.gnu.org/licenses/].
 
-import datetime
+import datetime as dtm
 from collections.abc import Sequence
 from copy import deepcopy
 
@@ -53,7 +53,7 @@ from tests.auxil.slots import mro_slots
 
 def withdrawal_state_succeeded():
     return RevenueWithdrawalStateSucceeded(
-        date=datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC),
+        date=dtm.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC),
         url="url",
     )
 
@@ -89,7 +89,7 @@ def transaction_partner_user():
             )
         ],
         paid_media_payload="payload",
-        subscription_period=datetime.timedelta(days=1),
+        subscription_period=dtm.timedelta(days=1),
         gift=Gift(
             id="some_id",
             sticker=Sticker(
@@ -126,7 +126,7 @@ def star_transaction():
         id="1",
         amount=1,
         nanostar_amount=365,
-        date=to_timestamp(datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC)),
+        date=to_timestamp(dtm.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC)),
         source=transaction_partner_user(),
         receiver=transaction_partner_fragment(),
     )
@@ -288,7 +288,7 @@ class StarTransactionTestBase:
     id = "2"
     amount = 2
     nanostar_amount = 365
-    date = to_timestamp(datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC))
+    date = to_timestamp(dtm.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC))
     source = TransactionPartnerUser(
         user=User(
             id=2,
@@ -370,7 +370,7 @@ class TestStarTransactionWithoutRequest(StarTransactionTestBase):
         c = StarTransaction(
             id="3",
             amount=3,
-            date=to_timestamp(datetime.datetime.utcnow()),
+            date=to_timestamp(dtm.datetime.utcnow()),
             source=TransactionPartnerUser(
                 user=User(
                     id=3,
@@ -539,7 +539,7 @@ class TestTransactionPartnerWithoutRequest(TransactionPartnerTestBase):
                 assert tp_dict[attr] == attribute.to_dict()
             elif not isinstance(attribute, str) and isinstance(attribute, Sequence):
                 assert tp_dict[attr] == [a.to_dict() for a in attribute]
-            elif isinstance(attribute, datetime.timedelta):
+            elif isinstance(attribute, dtm.timedelta):
                 assert tp_dict[attr] == attribute.total_seconds()
             else:
                 assert tp_dict[attr] == attribute
@@ -605,7 +605,7 @@ class TestTransactionPartnerUserWithoutRequest(TransactionPartnerTestBase):
 
 
 class RevenueWithdrawalStateTestBase:
-    date = datetime.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC)
+    date = dtm.datetime(2024, 1, 1, 0, 0, 0, 0, tzinfo=UTC)
     url = "url"
 
 
@@ -713,7 +713,7 @@ class TestRevenueWithdrawalStateWithoutRequest(RevenueWithdrawalStateTestBase):
 
         if hasattr(c, "date"):
             json_dict = c.to_dict()
-            json_dict["date"] = to_timestamp(datetime.datetime.utcnow())
+            json_dict["date"] = to_timestamp(dtm.datetime.utcnow())
             f = c.__class__.de_json(json_dict, offline_bot)
 
             assert c != f

--- a/tests/test_telegramobject.py
+++ b/tests/test_telegramobject.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
-import datetime
+import datetime as dtm
 import inspect
 import pickle
 import re
@@ -176,9 +176,7 @@ class TestTelegramObject:
         assert to.to_dict() == {"foo": "bar"}
 
     def test_to_dict_missing_attribute(self):
-        message = Message(
-            1, datetime.datetime.now(), Chat(1, "private"), from_user=User(1, "", False)
-        )
+        message = Message(1, dtm.datetime.now(), Chat(1, "private"), from_user=User(1, "", False))
         message._unfreeze()
         del message.chat
 
@@ -288,7 +286,7 @@ class TestTelegramObject:
     def test_pickle(self, bot):
         chat = Chat(2, Chat.PRIVATE)
         user = User(3, "first_name", False)
-        date = datetime.datetime.now()
+        date = dtm.datetime.now()
         photo = PhotoSize("file_id", "unique", 21, 21)
         photo.set_bot(bot)
         msg = Message(
@@ -432,7 +430,7 @@ class PicklePropertyTest(TelegramObject):
     def test_deepcopy_telegram_obj(self, bot):
         chat = Chat(2, Chat.PRIVATE)
         user = User(3, "first_name", False)
-        date = datetime.datetime.now()
+        date = dtm.datetime.now()
         photo = PhotoSize("file_id", "unique", 21, 21)
         photo.set_bot(bot)
         msg = Message(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -16,9 +16,9 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime as dtm
 import time
 from copy import deepcopy
-from datetime import datetime
 
 import pytest
 
@@ -57,7 +57,7 @@ from tests.auxil.slots import mro_slots
 
 message = Message(
     1,
-    datetime.utcnow(),
+    dtm.utcnow(),
     Chat(1, ""),
     from_user=User(1, "", False),
     text="Text",
@@ -65,7 +65,7 @@ message = Message(
 )
 channel_post = Message(
     1,
-    datetime.utcnow(),
+    dtm.utcnow(),
     Chat(1, ""),
     text="Text",
     sender_chat=Chat(1, ""),
@@ -139,7 +139,7 @@ deleted_business_messages = BusinessMessagesDeleted(
 
 business_message = Message(
     1,
-    datetime.utcnow(),
+    dtm.utcnow(),
     Chat(1, ""),
     User(1, "", False),
 )

--- a/tests/test_webhookinfo.py
+++ b/tests/test_webhookinfo.py
@@ -16,8 +16,8 @@
 #
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
+import datetime as dtm
 import time
-from datetime import datetime
 
 import pytest
 
@@ -89,12 +89,12 @@ class TestWebhookInfoWithoutRequest(WebhookInfoTestBase):
         assert webhook_info.url == self.url
         assert webhook_info.has_custom_certificate == self.has_custom_certificate
         assert webhook_info.pending_update_count == self.pending_update_count
-        assert isinstance(webhook_info.last_error_date, datetime)
+        assert isinstance(webhook_info.last_error_date, dtm)
         assert webhook_info.last_error_date == from_timestamp(self.last_error_date)
         assert webhook_info.max_connections == self.max_connections
         assert webhook_info.allowed_updates == tuple(self.allowed_updates)
         assert webhook_info.ip_address == self.ip_address
-        assert isinstance(webhook_info.last_synchronization_error_date, datetime)
+        assert isinstance(webhook_info.last_synchronization_error_date, dtm)
         assert webhook_info.last_synchronization_error_date == from_timestamp(
             self.last_synchronization_error_date
         )


### PR DESCRIPTION
## Qué?
Se ha realizado un refactor de los imports de datetime para estandarizar su uso a través de múltiples módulos y así mejorar la consistencia y legibilidad del código.

## Por qué?
Utilizar un alias consistente para los imports de datetime a través de diversos módulos ayuda a mantener un código más limpio, fácil de leer y de mantener.

## Cómo?
Se han modificado los siguientes archivos para utilizar un alias común (dtm) para los imports de datetime:

> test_messageorigin.py
> test_poll.py
> test_reply.py
> test_stars.py
> test_telegramobjects.py
> test_update.py
> test_videochat.py
> test_webhookinfo.py
> test_datetime.py
> bot_method_checks.py
> build_messages.py
> timezones.py
> test_businessconnectionhandler.py

